### PR TITLE
feat(example-plugin): 在示例插件中添加后台流式消息功能

### DIFF
--- a/src-tauri/src/plugins/example/Cargo.toml
+++ b/src-tauri/src/plugins/example/Cargo.toml
@@ -13,6 +13,7 @@ crate-type = ["cdylib"]
 toml = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+tokio = { version = "1.45.1", features = ["full"] }
 
 # 引用插件接口库
 plugin-interface = { path = "../../../plugin-interface" }


### PR DESCRIPTION
- 在 Cargo.toml 中添加 tokio 依赖，用于异步运行时
- 实现了在后台线程中发送流式消息的功能
- 添加了模拟真实后台处理的延迟
- 优化了日志信息，使其更具描述性
- 保留了原有功能，增加了新的后台流式消息演示按钮